### PR TITLE
Minor refactor of module's setup logic

### DIFF
--- a/playground/example.env
+++ b/playground/example.env
@@ -1,4 +1,4 @@
-COOLIFY_BASE_API_URL=<your-coolify-url>
-COOLIFY_API_TOKEN=<your-api-token>
-HETZNER_BASE_API_URL=<your-hetzner-api-url>
-HETZNER_API_TOKEN=<your-api-token>
+NUXT_COOLIFY_INSTANCES_DEFAULT_BASE_URL=<your-coolify-url>
+NUXT_COOLIFY_INSTANCES_DEFAULT_API_TOKEN=<your-coolify-api-token>
+NUXT_COOLIFY_PROVIDERS_HETZNER_BASE_URL=<your-hetzner-api-url>
+NUXT_COOLIFY_PROVIDERS_HETZNER_API_TOKEN=<your-hetzner-api-token>

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,23 +1,8 @@
 export default defineNuxtConfig({
   modules: ['../src/module'],
-  runtimeConfig: {
-    coolify: {
-      instances: {
-        default: {
-          baseUrl: process.env.COOLIFY_BASE_API_URL,
-          apiToken: process.env.COOLIFY_API_TOKEN,
-        },
-      },
-      enableProviders: true,
-      providers: {
-        hetzner: {
-          baseUrl: process.env.HETZNER_BASE_API_URL,
-          apiToken: process.env.HETZNER_API_TOKEN,
-        },
-      },
-    },
-  },
-  coolify: {},
+
+  // coolify options edited via `.env`
+
   devtools: { enabled: true },
   compatibilityDate: '2024-07-25',
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import {
   defineNuxtModule,
   createResolver,
@@ -43,11 +42,11 @@ export default defineNuxtModule<ModuleOptions>({
       },
     },
   },
-  async setup(_options, _nuxt) {
-    const nuxtOptions = _nuxt.options
+  async setup(options, nuxt) {
+    const nuxtOptions = nuxt.options
     const moduleOptions: ModuleOptions = defu(
       nuxtOptions.runtimeConfig.coolify || {},
-      _options,
+      options,
     )
     nuxtOptions.runtimeConfig.coolify = moduleOptions
 
@@ -59,7 +58,7 @@ export default defineNuxtModule<ModuleOptions>({
       console.warn('Please provide a valid API Token for your Coolify API.')
     }
 
-    _nuxt.hooks.hook('nitro:config', async (nitroConfig) => {
+    nuxt.hooks.hook('nitro:config', async (nitroConfig) => {
       nitroConfig.externals = nitroConfig.externals || {}
       nitroConfig.externals.inline = nitroConfig.externals.inline || []
       nitroConfig.externals.inline.push(resolver.resolve('./runtime'))
@@ -341,8 +340,8 @@ export default defineNuxtModule<ModuleOptions>({
       })
 
       await Promise.all([
-        Object.entries(hetznerServerHandlers).flatMap(([key, value]) =>
-          Object.entries(value).map(([subKey, subValue]) => {
+        Object.entries(hetznerServerHandlers).flatMap(([_key, value]) =>
+          Object.entries(value).map(([_subKey, subValue]) => {
             const { route, handler } = subValue
             return addServerHandler({
               route: route,
@@ -364,8 +363,8 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     await Promise.all([
-      Object.entries(coolifyServerHandlers).flatMap(([key, value]) =>
-        Object.entries(value).map(([subKey, subValue]) => {
+      Object.entries(coolifyServerHandlers).flatMap(([_key, value]) =>
+        Object.entries(value).map(([_subKey, subValue]) => {
           const { route, handler } = subValue
           return addServerHandler({
             route: route,

--- a/src/module.ts
+++ b/src/module.ts
@@ -5,18 +5,26 @@ import {
   addImports,
   addServerHandler,
 } from '@nuxt/kit'
+import { consola } from 'consola'
 import { defu } from 'defu'
+
+import {
+  addCoolifyServerHandlers,
+  addProvidersServerHandlers,
+} from './serverHandlers'
+
+export type ServerProviders = 'hetzner'
 
 // Module options TypeScript interface definition
 export interface ModuleOptions {
   instances: {
-    [key: string]: { apiToken: string, baseUrl: string }
+    [key: string | 'default']: { apiToken: string, baseUrl: string }
   }
   routeAlias?: string
   routeVersionAlias?: string
   enableProviders?: boolean
   providers?: {
-    [key: string]: { apiToken: string, baseUrl: string }
+    [key in ServerProviders]: { apiToken: string, baseUrl: string }
   }
 }
 
@@ -43,6 +51,8 @@ export default defineNuxtModule<ModuleOptions>({
     },
   },
   async setup(options, nuxt) {
+    const resolver = createResolver(import.meta.url)
+
     const nuxtOptions = nuxt.options
     const moduleOptions = defu<
       RuntimeConfig['coolify'],
@@ -54,11 +64,11 @@ export default defineNuxtModule<ModuleOptions>({
     nuxtOptions.runtimeConfig.coolify = moduleOptions
 
     if (moduleOptions.instances['default'].baseUrl === 'missing') {
-      console.warn('Please provide the base URL for your Coolify API. Ex: https://api.coolify.io')
+      consola.warn('Please provide the base URL for your Coolify API. Ex: https://api.coolify.io')
     }
 
     if (moduleOptions.instances['default'].apiToken === 'missing') {
-      console.warn('Please provide a valid API Token for your Coolify API.')
+      consola.warn('Please provide a valid API Token for your Coolify API.')
     }
 
     nuxt.hooks.hook('nitro:config', async (nitroConfig) => {
@@ -66,294 +76,6 @@ export default defineNuxtModule<ModuleOptions>({
       nitroConfig.externals.inline = nitroConfig.externals.inline || []
       nitroConfig.externals.inline.push(resolver.resolve('./runtime'))
     })
-
-    const resolver = createResolver(import.meta.url)
-    const route = `/api/${moduleOptions.routeVersionAlias}/${moduleOptions.routeAlias}`
-
-    const runtimeRoute = './runtime/server/api/_v1/_coolify'
-    const coolifyServerHandlers = {
-      authorisation: {
-        healthcheck: {
-          route: `${route}/authorisation/healthcheck`,
-          handler: `${runtimeRoute}/authorisation/healthcheck.get`,
-        },
-        enable: {
-          route: `${route}/authorisation/enable`,
-          handler: `${runtimeRoute}/authorisation/enable.get`,
-        },
-        disable: {
-          route: `${route}/authorisation/disable`,
-          handler: `${runtimeRoute}/authorisation/disable.get`,
-        },
-        version: {
-          route: `${route}/authorisation/version`,
-          handler: `${runtimeRoute}/authorisation/version.get`,
-        },
-      },
-      projects: {
-        create: {
-          route: `${route}/projects/create`,
-          handler: `${runtimeRoute}/projects/create.post`,
-        },
-        list: {
-          route: `${route}/projects/list`,
-          handler: `${runtimeRoute}/projects/list.get`,
-        },
-        get: {
-          route: `${route}/projects/:uuid`,
-          handler: `${runtimeRoute}/projects/[uuid]/index.get`,
-        },
-        delete: {
-          route: `${route}/projects/:uuid/delete`,
-          handler: `${runtimeRoute}/projects/[uuid]/delete.get`,
-        },
-        update: {
-          route: `${route}/projects/:uuid/update`,
-          handler: `${runtimeRoute}/projects/[uuid]/update.post`,
-        },
-        project_environment: {
-          route: `${route}/projects/:uuid/:environment_name`,
-          handler: `${runtimeRoute}/projects/[uuid]/[environment_name]/index.get`,
-        },
-      },
-      servers: {
-        create: {
-          route: `${route}/servers/create`,
-          handler: `${runtimeRoute}/servers/create.post`,
-        },
-        list: {
-          route: `${route}/servers/list`,
-          handler: `${runtimeRoute}/servers/list.get`,
-        },
-        get: {
-          route: `${route}/servers/:uuid`,
-          handler: `${runtimeRoute}/servers/[uuid]/index.get`,
-        },
-        delete: {
-          route: `${route}/servers/:uuid/delete`,
-          handler: `${runtimeRoute}/projects/[uuid]/delete.get`,
-        },
-        update: {
-          route: `${route}/servers/:uuid/update`,
-          handler: `${runtimeRoute}/servers/[uuid]/update.post`,
-        },
-        domains: {
-          route: `${route}/servers/:uuid/domains`,
-          handler: `${runtimeRoute}/servers/[uuid]/domains.get`,
-        },
-        resources: {
-          route: `${route}/servers/:uuid/resources`,
-          handler: `${runtimeRoute}/servers/[uuid]/resources.get`,
-        },
-        validate: {
-          route: `${route}/servers/:uuid/validate`,
-          handler: `${runtimeRoute}/servers/[uuid]/validate.get`,
-        },
-      },
-      deploy: {
-        create: {
-          route: `${route}/deploy`,
-          handler: `${runtimeRoute}/deploy/index.post`,
-        },
-      },
-      deployments: {
-        get: {
-          route: `${route}/deployments/:uuid`,
-          handler: `${runtimeRoute}/deployments/[uuid]/index.get`,
-        },
-        list: {
-          route: `${route}/deployments`,
-          handler: `${runtimeRoute}/deployments/list.get`,
-        },
-      },
-      services: {
-        create: {
-          route: `${route}/services/create`,
-          handler: `${runtimeRoute}/servers/create.post`,
-        },
-        list: {
-          route: `${route}/services/list`,
-          handler: `${runtimeRoute}/servers/list.get`,
-        },
-        get: {
-          route: `${route}/services/:uuid`,
-          handler: `${runtimeRoute}/services/[uuid]/index.get`,
-        },
-        delete: {
-          route: `${route}/services/:uuid/delete`,
-          handler: `${runtimeRoute}/services/[uuid]/delete.get`,
-        },
-        start: {
-          route: `${route}/services/:uuid/start`,
-          handler: `${runtimeRoute}/services/[uuid]/start.get`,
-        },
-        stop: {
-          route: `${route}/services/:uuid/stop`,
-          handler: `${runtimeRoute}/services/[uuid]/stop.get`,
-        },
-        restart: {
-          route: `${route}/services/:uuid/restart`,
-          handler: `${runtimeRoute}/services/[uuid]/restart.get`,
-        },
-      },
-      teams: {
-        list: {
-          route: `${route}/teams/list`,
-          handler: `${runtimeRoute}/teams/list.get`,
-        },
-        get: {
-          route: `${route}/teams/:id`,
-          handler: `${runtimeRoute}/teams/[id]/index.get`,
-        },
-        members: {
-          route: `${route}/teams/:id/members`,
-          handler: `${runtimeRoute}/teams/[id]/members.get`,
-        },
-        activeTeam: {
-          route: `${route}/teams/current`,
-          handler: `${runtimeRoute}/teams/current/index.get`,
-        },
-        activeTeamMembers: {
-          route: `${route}/teams/current/members`,
-          handler: `${runtimeRoute}/teams/current/members.get`,
-        },
-      },
-      instances: {
-        list: {
-          route: `${route}/instances`,
-          handler: `${runtimeRoute}/instances/index.get`,
-        },
-      },
-      resources: {
-        list: {
-          route: `${route}/resources/list`,
-          handler: `${runtimeRoute}/resources/list.get`,
-        },
-      },
-    }
-
-    if (moduleOptions.enableProviders) {
-      if (!moduleOptions.providers || Object.keys(moduleOptions.providers).length === 0) {
-        throw new Error('Please provide at least one provider. Note: Hetzner only at the moment.')
-      }
-
-      const providerEntries = Object.entries(moduleOptions.providers)
-
-      if (providerEntries.length === 0) {
-        throw new Error('No supported providers found after parsing. Please check your configuration.')
-      }
-
-      let providerRoute, providerRuntimeRoute
-
-      for (const [providerName, providerConfig] of providerEntries) {
-        if (providerName !== 'hetzner') {
-          console.warn(`Provider ${providerName} is not currently supported and will be skipped. Only Hetzner is supported at the moment.`)
-          continue
-        }
-
-        if (!providerConfig.apiToken || providerConfig.apiToken === 'missing') {
-          console.warn(`Please provide a valid API Token for the ${providerName} provider.`)
-        }
-
-        providerRoute = `/api/${moduleOptions.routeVersionAlias}/_${providerName}`
-        providerRuntimeRoute = `./runtime/server/api/${moduleOptions.routeVersionAlias}/_${providerName}`
-      }
-
-      const hetznerServerHandlers = {
-        servers: {
-          all: {
-            route: `${providerRoute}/servers`,
-            handler: `${providerRuntimeRoute}/servers/index.get`,
-          },
-          create: {
-            route: `${providerRoute}/servers/:id`,
-            handler: `${providerRuntimeRoute}/servers/create.post`,
-          },
-          delete: {
-            route: `${providerRoute}/servers/:id/delete`,
-            handler: `${providerRuntimeRoute}/servers/[id]/delete.get`,
-          },
-          get: {
-            route: `${providerRoute}/servers/:id`,
-            handler: `${providerRuntimeRoute}/servers/[id]/index.get`,
-          },
-          update: {
-            route: `${providerRoute}/servers/:id/update`,
-            handler: `${providerRuntimeRoute}/servers/[id]/update.post`,
-          },
-          metrics: {
-            route: `${providerRoute}/servers/:id/metrics`,
-            handler: `${providerRuntimeRoute}/servers/[id]/metrics.get`,
-          },
-          allServerActions: {
-            route: `${providerRoute}/servers/actions`,
-            handler: `${providerRuntimeRoute}/servers/actions/index.get`,
-          },
-          getServerAction: {
-            route: `${providerRoute}/servers/actions/:id`,
-            handler: `${providerRuntimeRoute}/servers/actions/[id]/index.get`,
-          },
-          getServerActionByActionId: {
-            route: `${providerRoute}/servers/:id/actions/:actionId`,
-            handler: `${providerRuntimeRoute}/servers/[id]/actions/[actionId]/index.get`,
-          },
-          commandServer: {
-            route: `${providerRoute}/servers/:id/actions/commands/:action`,
-            handler: `${providerRuntimeRoute}/servers/[id]/actions/commands/[action].post`,
-          },
-          requestServerConsole: {
-            route: `${providerRoute}/servers/:id/actions/console`,
-            handler: `${providerRuntimeRoute}/servers/[id]/actions/console.post`,
-          },
-          getLocations: {
-            route: `${providerRoute}/locations`,
-            handler: `${providerRuntimeRoute}/locations/index.get`,
-          },
-          getLocation: {
-            route: `${providerRoute}/locations/:id`,
-            handler: `${providerRuntimeRoute}/locations/[id]/index.get`,
-          },
-          getDatacenters: {
-            route: `${providerRoute}/datacenters`,
-            handler: `${providerRuntimeRoute}/datacenters/index.get`,
-          },
-          getDatacenter: {
-            route: `${providerRoute}/datacenters/:id`,
-            handler: `${providerRuntimeRoute}/datacenters/[id]/index.get`,
-          },
-          getServerTypes: {
-            route: `${providerRoute}/servers/types`,
-            handler: `${providerRuntimeRoute}/servers/index.get`,
-          },
-          getServerType: {
-            route: `${providerRoute}/servers/types/:id`,
-            handler: `${providerRuntimeRoute}/servers/types/[id]/index.get`,
-          },
-        },
-      }
-
-      addImports({
-        name: 'useHetzner',
-        as: 'useHetzner',
-        from: resolver.resolve('runtime/composables/useHetzner'),
-      })
-      addServerHandler({
-        middleware: true,
-        handler: resolver.resolve('./runtime/server/middleware/hetzner'),
-      })
-
-      await Promise.all([
-        Object.entries(hetznerServerHandlers).flatMap(([_key, value]) =>
-          Object.entries(value).map(([_subKey, subValue]) => {
-            const { route, handler } = subValue
-            return addServerHandler({
-              route: route,
-              handler: resolver.resolve(handler),
-            })
-          }),
-        ),
-      ])
-    }
 
     addImports({
       name: 'useCoolify',
@@ -365,16 +87,7 @@ export default defineNuxtModule<ModuleOptions>({
       handler: resolver.resolve('./runtime/server/middleware/coolify'),
     })
 
-    await Promise.all([
-      Object.entries(coolifyServerHandlers).flatMap(([_key, value]) =>
-        Object.entries(value).map(([_subKey, subValue]) => {
-          const { route, handler } = subValue
-          return addServerHandler({
-            route: route,
-            handler: resolver.resolve(handler),
-          })
-        }),
-      ),
-    ])
+    addCoolifyServerHandlers(resolver, moduleOptions)
+    addProvidersServerHandlers(resolver, moduleOptions)
   },
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,7 @@
+import type { RuntimeConfig } from '@nuxt/schema'
 import {
   defineNuxtModule,
   createResolver,
-  addImportsDir,
   addImports,
   addServerHandler,
 } from '@nuxt/kit'
@@ -44,7 +44,10 @@ export default defineNuxtModule<ModuleOptions>({
   },
   async setup(options, nuxt) {
     const nuxtOptions = nuxt.options
-    const moduleOptions: ModuleOptions = defu(
+    const moduleOptions = defu<
+      RuntimeConfig['coolify'],
+      ModuleOptions[]
+    >(
       nuxtOptions.runtimeConfig.coolify || {},
       options,
     )

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,7 @@
+import type { RuntimeConfig } from '@nuxt/schema'
 import {
   defineNuxtModule,
   createResolver,
-  addImportsDir,
   addImports,
   addServerHandler,
 } from '@nuxt/kit'
@@ -44,8 +44,11 @@ export default defineNuxtModule<ModuleOptions>({
   },
   async setup(options, nuxt) {
     const nuxtOptions = nuxt.options
-    const moduleOptions: ModuleOptions = defu(
-      nuxtOptions.runtimeConfig.coolify || {},
+    const moduleOptions = defu<
+      RuntimeConfig['coolify'],
+      ModuleOptions[]
+    >(
+      nuxtOptions.runtimeConfig.coolify,
       options,
     )
     nuxtOptions.runtimeConfig.coolify = moduleOptions

--- a/src/module.ts
+++ b/src/module.ts
@@ -36,8 +36,8 @@ export default defineNuxtModule<ModuleOptions>({
   defaults: {
     instances: {
       default: {
-        baseUrl: process.env.COOLIFY_BASE_API_URL || 'missing',
-        apiToken: process.env.COOLIFY_API_TOKEN || 'missing',
+        baseUrl: '', // NUXT_COOLIFY_INSTANCES_DEFAULT_BASE_URL
+        apiToken: '', // NUXT_COOLIFY_INSTANCES_DEFAULT_API_TOKEN
       },
     },
     routeAlias: '_coolify',
@@ -45,8 +45,8 @@ export default defineNuxtModule<ModuleOptions>({
     enableProviders: false,
     providers: {
       hetzner: {
-        apiToken: process.env.HETZNER_API_TOKEN || 'missing',
-        baseUrl: process.env.HETZNER_BASE_API_URL || 'https://api.hetzner.cloud/v1',
+        baseUrl: 'https://api.hetzner.cloud/v1', // NUXT_COOLIFY_PROVIDERS_HETZNER_BASE_URL
+        apiToken: '', // NUXT_COOLIFY_PROVIDERS_HETZNER_API_TOKEN
       },
     },
   },

--- a/src/serverHandlers/coolify.ts
+++ b/src/serverHandlers/coolify.ts
@@ -1,0 +1,183 @@
+import type { RuntimeConfig } from '@nuxt/schema'
+import {
+  type Resolver,
+  addServerHandler,
+} from '@nuxt/kit'
+
+export function addCoolifyServerHandlers(resolver: Resolver, moduleOptions: RuntimeConfig['coolify']) {
+  const route = `/api/${moduleOptions.routeVersionAlias}/${moduleOptions.routeAlias}`
+  const runtimeRoute = './runtime/server/api/_v1/_coolify'
+
+  const coolifyServerHandlers = {
+    authorisation: {
+      healthcheck: {
+        route: `${route}/authorisation/healthcheck`,
+        handler: `${runtimeRoute}/authorisation/healthcheck.get`,
+      },
+      enable: {
+        route: `${route}/authorisation/enable`,
+        handler: `${runtimeRoute}/authorisation/enable.get`,
+      },
+      disable: {
+        route: `${route}/authorisation/disable`,
+        handler: `${runtimeRoute}/authorisation/disable.get`,
+      },
+      version: {
+        route: `${route}/authorisation/version`,
+        handler: `${runtimeRoute}/authorisation/version.get`,
+      },
+    },
+    projects: {
+      create: {
+        route: `${route}/projects/create`,
+        handler: `${runtimeRoute}/projects/create.post`,
+      },
+      list: {
+        route: `${route}/projects/list`,
+        handler: `${runtimeRoute}/projects/list.get`,
+      },
+      get: {
+        route: `${route}/projects/:uuid`,
+        handler: `${runtimeRoute}/projects/[uuid]/index.get`,
+      },
+      delete: {
+        route: `${route}/projects/:uuid/delete`,
+        handler: `${runtimeRoute}/projects/[uuid]/delete.get`,
+      },
+      update: {
+        route: `${route}/projects/:uuid/update`,
+        handler: `${runtimeRoute}/projects/[uuid]/update.post`,
+      },
+      project_environment: {
+        route: `${route}/projects/:uuid/:environment_name`,
+        handler: `${runtimeRoute}/projects/[uuid]/[environment_name]/index.get`,
+      },
+    },
+    servers: {
+      create: {
+        route: `${route}/servers/create`,
+        handler: `${runtimeRoute}/servers/create.post`,
+      },
+      list: {
+        route: `${route}/servers/list`,
+        handler: `${runtimeRoute}/servers/list.get`,
+      },
+      get: {
+        route: `${route}/servers/:uuid`,
+        handler: `${runtimeRoute}/servers/[uuid]/index.get`,
+      },
+      delete: {
+        route: `${route}/servers/:uuid/delete`,
+        handler: `${runtimeRoute}/projects/[uuid]/delete.get`,
+      },
+      update: {
+        route: `${route}/servers/:uuid/update`,
+        handler: `${runtimeRoute}/servers/[uuid]/update.post`,
+      },
+      domains: {
+        route: `${route}/servers/:uuid/domains`,
+        handler: `${runtimeRoute}/servers/[uuid]/domains.get`,
+      },
+      resources: {
+        route: `${route}/servers/:uuid/resources`,
+        handler: `${runtimeRoute}/servers/[uuid]/resources.get`,
+      },
+      validate: {
+        route: `${route}/servers/:uuid/validate`,
+        handler: `${runtimeRoute}/servers/[uuid]/validate.get`,
+      },
+    },
+    deploy: {
+      create: {
+        route: `${route}/deploy`,
+        handler: `${runtimeRoute}/deploy/index.post`,
+      },
+    },
+    deployments: {
+      get: {
+        route: `${route}/deployments/:uuid`,
+        handler: `${runtimeRoute}/deployments/[uuid]/index.get`,
+      },
+      list: {
+        route: `${route}/deployments`,
+        handler: `${runtimeRoute}/deployments/list.get`,
+      },
+    },
+    services: {
+      create: {
+        route: `${route}/services/create`,
+        handler: `${runtimeRoute}/servers/create.post`,
+      },
+      list: {
+        route: `${route}/services/list`,
+        handler: `${runtimeRoute}/servers/list.get`,
+      },
+      get: {
+        route: `${route}/services/:uuid`,
+        handler: `${runtimeRoute}/services/[uuid]/index.get`,
+      },
+      delete: {
+        route: `${route}/services/:uuid/delete`,
+        handler: `${runtimeRoute}/services/[uuid]/delete.get`,
+      },
+      start: {
+        route: `${route}/services/:uuid/start`,
+        handler: `${runtimeRoute}/services/[uuid]/start.get`,
+      },
+      stop: {
+        route: `${route}/services/:uuid/stop`,
+        handler: `${runtimeRoute}/services/[uuid]/stop.get`,
+      },
+      restart: {
+        route: `${route}/services/:uuid/restart`,
+        handler: `${runtimeRoute}/services/[uuid]/restart.get`,
+      },
+    },
+    teams: {
+      list: {
+        route: `${route}/teams/list`,
+        handler: `${runtimeRoute}/teams/list.get`,
+      },
+      get: {
+        route: `${route}/teams/:id`,
+        handler: `${runtimeRoute}/teams/[id]/index.get`,
+      },
+      members: {
+        route: `${route}/teams/:id/members`,
+        handler: `${runtimeRoute}/teams/[id]/members.get`,
+      },
+      activeTeam: {
+        route: `${route}/teams/current`,
+        handler: `${runtimeRoute}/teams/current/index.get`,
+      },
+      activeTeamMembers: {
+        route: `${route}/teams/current/members`,
+        handler: `${runtimeRoute}/teams/current/members.get`,
+      },
+    },
+    instances: {
+      list: {
+        route: `${route}/instances`,
+        handler: `${runtimeRoute}/instances/index.get`,
+      },
+    },
+    resources: {
+      list: {
+        route: `${route}/resources/list`,
+        handler: `${runtimeRoute}/resources/list.get`,
+      },
+    },
+  }
+
+  Object.entries(coolifyServerHandlers).flatMap(([_key, value]) =>
+    Object.entries(value).map(([_subKey, subValue]) => {
+      const { route, handler } = subValue
+      return addServerHandler({
+        route: route,
+        handler: resolver.resolve(handler),
+      })
+    }),
+  )
+}
+
+export default addCoolifyServerHandlers

--- a/src/serverHandlers/index.ts
+++ b/src/serverHandlers/index.ts
@@ -1,0 +1,2 @@
+export * from './coolify'
+export * from './providers'

--- a/src/serverHandlers/providers/hetzner.ts
+++ b/src/serverHandlers/providers/hetzner.ts
@@ -1,0 +1,112 @@
+import type { RuntimeConfig } from '@nuxt/schema'
+import { consola } from 'consola'
+import {
+  type Resolver,
+  addServerHandler,
+  addImports,
+} from '@nuxt/kit'
+
+export function addHetznerServerHandlers(resolver: Resolver, moduleOptions: RuntimeConfig['coolify']) {
+  if (!moduleOptions.providers['hetzner'].apiToken) {
+    consola.warn(`Missing a valid API Token for Hetzner, skipping initialization.`)
+    return
+  }
+
+  const providerRoute = `/api/${moduleOptions.routeVersionAlias}/_hetzner`
+  const providerRuntimeRoute = `./runtime/server/api/${moduleOptions.routeVersionAlias}/_hetzner`
+
+  const hetznerServerHandlers = {
+    servers: {
+      all: {
+        route: `${providerRoute}/servers`,
+        handler: `${providerRuntimeRoute}/servers/index.get`,
+      },
+      create: {
+        route: `${providerRoute}/servers/:id`,
+        handler: `${providerRuntimeRoute}/servers/create.post`,
+      },
+      delete: {
+        route: `${providerRoute}/servers/:id/delete`,
+        handler: `${providerRuntimeRoute}/servers/[id]/delete.get`,
+      },
+      get: {
+        route: `${providerRoute}/servers/:id`,
+        handler: `${providerRuntimeRoute}/servers/[id]/index.get`,
+      },
+      update: {
+        route: `${providerRoute}/servers/:id/update`,
+        handler: `${providerRuntimeRoute}/servers/[id]/update.post`,
+      },
+      metrics: {
+        route: `${providerRoute}/servers/:id/metrics`,
+        handler: `${providerRuntimeRoute}/servers/[id]/metrics.get`,
+      },
+      allServerActions: {
+        route: `${providerRoute}/servers/actions`,
+        handler: `${providerRuntimeRoute}/servers/actions/index.get`,
+      },
+      getServerAction: {
+        route: `${providerRoute}/servers/actions/:id`,
+        handler: `${providerRuntimeRoute}/servers/actions/[id]/index.get`,
+      },
+      getServerActionByActionId: {
+        route: `${providerRoute}/servers/:id/actions/:actionId`,
+        handler: `${providerRuntimeRoute}/servers/[id]/actions/[actionId]/index.get`,
+      },
+      commandServer: {
+        route: `${providerRoute}/servers/:id/actions/commands/:action`,
+        handler: `${providerRuntimeRoute}/servers/[id]/actions/commands/[action].post`,
+      },
+      requestServerConsole: {
+        route: `${providerRoute}/servers/:id/actions/console`,
+        handler: `${providerRuntimeRoute}/servers/[id]/actions/console.post`,
+      },
+      getLocations: {
+        route: `${providerRoute}/locations`,
+        handler: `${providerRuntimeRoute}/locations/index.get`,
+      },
+      getLocation: {
+        route: `${providerRoute}/locations/:id`,
+        handler: `${providerRuntimeRoute}/locations/[id]/index.get`,
+      },
+      getDatacenters: {
+        route: `${providerRoute}/datacenters`,
+        handler: `${providerRuntimeRoute}/datacenters/index.get`,
+      },
+      getDatacenter: {
+        route: `${providerRoute}/datacenters/:id`,
+        handler: `${providerRuntimeRoute}/datacenters/[id]/index.get`,
+      },
+      getServerTypes: {
+        route: `${providerRoute}/servers/types`,
+        handler: `${providerRuntimeRoute}/servers/index.get`,
+      },
+      getServerType: {
+        route: `${providerRoute}/servers/types/:id`,
+        handler: `${providerRuntimeRoute}/servers/types/[id]/index.get`,
+      },
+    },
+  }
+
+  addImports({
+    name: 'useHetzner',
+    as: 'useHetzner',
+    from: resolver.resolve('./runtime/composables/useHetzner'),
+  })
+  addServerHandler({
+    middleware: true,
+    handler: resolver.resolve('./runtime/server/middleware/hetzner'),
+  })
+
+  Object.entries(hetznerServerHandlers).flatMap(([_key, value]) =>
+    Object.entries(value).map(([_subKey, subValue]) => {
+      const { route, handler } = subValue
+      return addServerHandler({
+        route: route,
+        handler: resolver.resolve(handler),
+      })
+    }),
+  )
+}
+
+export default addHetznerServerHandlers

--- a/src/serverHandlers/providers/index.ts
+++ b/src/serverHandlers/providers/index.ts
@@ -1,0 +1,27 @@
+import type { RuntimeConfig } from '@nuxt/schema'
+import { type Resolver } from '@nuxt/kit'
+import { consola } from 'consola'
+
+import type {
+  ServerProviders,
+} from '../../module'
+import {
+  addHetznerServerHandlers,
+} from './hetzner'
+
+export function addProvidersServerHandlers(resolver: Resolver, moduleOptions: RuntimeConfig['coolify']) {
+  if (!moduleOptions.enableProviders) return
+
+  const providerEntries = Object.entries(moduleOptions.providers)
+  const allowedServerProviders: ServerProviders[] = ['hetzner']
+
+  for (const [providerName] of providerEntries) {
+    if (allowedServerProviders.includes(providerName as ServerProviders)) {
+      consola.warn(`Provider ${providerName} is not currently supported and will be skipped. Only Hetzner is supported at the moment.`)
+      continue
+    }
+  }
+
+  addHetznerServerHandlers(resolver, moduleOptions)
+  // Add additional providers
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "extends": "./.nuxt/tsconfig.json",
-  "compilerOptions": {
-    "moduleResolution": "nodenext",
-    "target": "esnext",
-    "module": "NodeNext",
-  },
   "exclude": [
+    "docs",
     "dist",
     "node_modules",
     "playground",


### PR DESCRIPTION
Thanks again @justserdar for this project idea.

This is the first (two panned, for now) PRs I have in mind. Please feel free to discard or comment any, or all, the changes I suggest.
This first one focuses on streamlining some of the core concepts when building Nuxt modules.

### Reasons

Let me explain some of the changes:

1. removed the following `if` check (from the provider's serverHandler initialization), since `hetzner` provider is always defined in module's defaults
    ```ts
    if (!moduleOptions.providers || Object.keys(moduleOptions.providers).length === 0) {
      throw new Error('Please provide at least one provider. Note: Hetzner only at the moment.')
    }

    // [...]

    if (providerEntries.length === 0) {
      throw new Error('No supported providers found after parsing. Please check your configuration.')
    }
    ```
2. Refactored all `addServerHandler` initializzations, to simplify future implementations
3. Removed the `Promise.all` logic when injecting each `addServerHandler` (correct me if I'm wrong, but I don't see any particular advantage in doing so since all operations are synchronous)
4. Fixed environment variables, making them runtime safe (not hardcoding them during `nuxt build`/`nuxt generate`)

### Next PR

It will be a followup to this one, taking advantage of the new function-based initialization of serverHandlers. It will also allow me to separate the api versioning between coolify and each providers, while also not requiring the use of those complex object maps for each handler. (I'm realizing, writing this, that I could be not explaining my self correctly, but the idea is that instead of handling the `routeVersionAlias` globally I would separate it between `coolify` and each provider, as well binding it directly to the folders during import instead of those big and hard-to-maintain object maps)

### Questions

1. What is the advantage of letting people change `routeAlias: '_coolify'`? Personally speaking I would go for a more opinionated way, hardcoding `_coolify` (this will greatly simplify maintainability since it will let me completely get rid of those object maps in the next PR). But, if you would like to keep it, then I would suggest to add it also for each provider. Since, to me, it doesn't make much sense having a this option for coolify, but not for each server provider (but this then will require to keep those object maps, again increasing the module's maintainability in the long-term, in particular when dealing with non-breaking api versions)