### PR TITLE
Initial fix after first rewrite

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,7 +1,9 @@
 export default defineNuxtConfig({
   modules: ['../src/module'],
 
-  // coolify options edited via `.env`
+  coolify: {
+    enableProviders: true,
+  },
 
   devtools: { enabled: true },
   compatibilityDate: '2024-07-25',

--- a/src/module.ts
+++ b/src/module.ts
@@ -24,7 +24,7 @@ export interface ModuleOptions {
   routeVersionAlias?: string
   enableProviders?: boolean
   providers?: {
-    [key in ServerProviders]: { apiToken: string, baseUrl: string }
+    [key in ServerProviders]: { apiToken: string, baseUrl?: string }
   }
 }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -53,15 +53,13 @@ export default defineNuxtModule<ModuleOptions>({
   async setup(options, nuxt) {
     const resolver = createResolver(import.meta.url)
 
-    const nuxtOptions = nuxt.options
-    const moduleOptions = defu<
+    const moduleOptions = nuxt.options.runtimeConfig.coolify = defu<
       RuntimeConfig['coolify'],
       ModuleOptions[]
     >(
-      nuxtOptions.runtimeConfig.coolify,
+      nuxt.options.runtimeConfig.coolify,
       options,
     )
-    nuxtOptions.runtimeConfig.coolify = moduleOptions
 
     if (moduleOptions.instances['default'].baseUrl === 'missing') {
       consola.warn('Please provide the base URL for your Coolify API. Ex: https://api.coolify.io')

--- a/src/module.ts
+++ b/src/module.ts
@@ -78,7 +78,7 @@ export default defineNuxtModule<ModuleOptions>({
     addImports({
       name: 'useCoolify',
       as: 'useCoolify',
-      from: resolver.resolve('runtime/composables/useCoolify'),
+      from: resolver.resolve('./runtime/composables/useCoolify'),
     })
     addServerHandler({
       middleware: true,

--- a/src/module.ts
+++ b/src/module.ts
@@ -61,11 +61,11 @@ export default defineNuxtModule<ModuleOptions>({
       options,
     )
 
-    if (moduleOptions.instances['default'].baseUrl === 'missing') {
+    if (!moduleOptions.instances['default'].baseUrl) {
       consola.warn('Please provide the base URL for your Coolify API. Ex: https://api.coolify.io')
     }
 
-    if (moduleOptions.instances['default'].apiToken === 'missing') {
+    if (!moduleOptions.instances['default'].apiToken) {
       consola.warn('Please provide a valid API Token for your Coolify API.')
     }
 

--- a/src/serverHandlers/providers/index.ts
+++ b/src/serverHandlers/providers/index.ts
@@ -16,7 +16,7 @@ export function addProvidersServerHandlers(resolver: Resolver, moduleOptions: Ru
   const allowedServerProviders: ServerProviders[] = ['hetzner']
 
   for (const [providerName] of providerEntries) {
-    if (allowedServerProviders.includes(providerName as ServerProviders)) {
+    if (!allowedServerProviders.includes(providerName as ServerProviders)) {
       consola.warn(`Provider ${providerName} is not currently supported and will be skipped. Only Hetzner is supported at the moment.`)
       continue
     }


### PR DESCRIPTION
Followup to #1 (and private discord discussions).

This fixes up some wrongly set conditionals (ups 😜) as well simplifies the runtimeConfig update.
But while implementing these fixes I've also noticed that I should propose a slightly different logic on WHEN the providers utils are imported. Currently Nuxt checks if they are required during one of the first hooks, where it reads the `nuxt.config.ts` but not yet the `.env`. This breaks some of the conditional imports, in particular server provider's ones